### PR TITLE
Refactor coupon schema

### DIFF
--- a/src/main/java/com/example/mycoupon/config/CouponApplicationInitializer.java
+++ b/src/main/java/com/example/mycoupon/config/CouponApplicationInitializer.java
@@ -1,0 +1,19 @@
+package com.example.mycoupon.config;
+
+import org.springframework.web.WebApplicationInitializer;
+import org.springframework.web.servlet.DispatcherServlet;
+
+import javax.servlet.ServletContext;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRegistration;
+
+public class CouponApplicationInitializer implements WebApplicationInitializer {
+    // 스프링 MVC에서 비동기 요청 처리를 사용하려면 모든 필터와 서블릿이 비동기로 작동하게끔 활성화해야 한다.
+    // 필터 / 서블릿을 등록할 때 setAsyncSupported(true) 메서드를 호출하면 비동기모드가 켜진다.
+    @Override
+    public void onStartup(ServletContext servletContext) throws ServletException {
+        DispatcherServlet servlet = new DispatcherServlet();
+        ServletRegistration.Dynamic registration = servletContext.addServlet("dispatcher", servlet);
+        registration.setAsyncSupported(true);
+    }
+}

--- a/src/main/java/com/example/mycoupon/config/CustomControllerAdvice.java
+++ b/src/main/java/com/example/mycoupon/config/CustomControllerAdvice.java
@@ -1,9 +1,6 @@
 package com.example.mycoupon.config;
 
-import com.example.mycoupon.exceptions.CouponMemberNotMatchException;
-import com.example.mycoupon.exceptions.CouponNotFoundException;
-import com.example.mycoupon.exceptions.InvalidPayloadException;
-import com.example.mycoupon.exceptions.MemberNotFoundException;
+import com.example.mycoupon.exceptions.*;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -30,6 +27,11 @@ public class CustomControllerAdvice {
     @ExceptionHandler(InvalidPayloadException.class)
     ResponseEntity<Object> invalidPayloadException(InvalidPayloadException e) {
         return this.error(e, HttpStatus.BAD_REQUEST, e.getLocalizedMessage());
+    }
+
+    @ExceptionHandler(InternalFailureException.class)
+    ResponseEntity<Object> internalFailureException(InternalFailureException e) {
+        return this.error(e, HttpStatus.INTERNAL_SERVER_ERROR, e.getLocalizedMessage());
     }
 
     private <E extends Exception> ResponseEntity<Object> error(E error, HttpStatus httpStatus, String msg) {

--- a/src/main/java/com/example/mycoupon/controller/CouponController.java
+++ b/src/main/java/com/example/mycoupon/controller/CouponController.java
@@ -22,6 +22,8 @@ import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import static java.util.concurrent.CompletableFuture.completedFuture;
+
 /*
 JwyAuthorizationFilter 로직을 컨트롤러 진입 전에 먼저 타서 헤더의 토큰이 유효한 지 검사 후 ->
 토큰이 유효하면, memberId를 Request attribute에 담아 컨트롤러로 전달한다.
@@ -40,7 +42,7 @@ public class CouponController {
     }
 
     @PostMapping("/{num}")
-    public ResponseEntity<?> saveCoupon(@PathVariable("num") int num, @RequestAttribute Long memberId) throws InterruptedException {
+    public CompletableFuture<ResponseEntity<?>> saveCoupon(@PathVariable("num") int num, @RequestAttribute Long memberId) throws InterruptedException {
         if(num > 100000) {
             throw new InvalidPayloadException("The number of coupon should be less than 1000000.");
         }
@@ -49,21 +51,19 @@ public class CouponController {
                 .mapToObj(i -> couponservice.save())
                 .collect(Collectors.toList());
 
-        CompletableFuture.allOf(futureList.toArray(new CompletableFuture[num]))
-                .thenAccept(s -> log.info("Computation returned: " + s));
-
-        URI selfLink = URI.create(
-                ServletUriComponentsBuilder.fromCurrentRequest().toUriString()
-        );
-        return ResponseEntity.created(selfLink).build();
+        return CompletableFuture.allOf(futureList.toArray(new CompletableFuture[num]))
+                .thenApply((s) -> ResponseEntity.created(
+                        URI.create(ServletUriComponentsBuilder.fromCurrentRequest().toUriString())
+                ).build());
     }
 
     @PutMapping("/user")
-    public ResponseEntity<String> assignToUserCouponAsync(@RequestAttribute("memberId") Long memberId) throws MemberNotFoundException, ExecutionException, InterruptedException { // user_id는 JwtAuthorizationFilter에서 넘겨줌.
+    public CompletableFuture<ResponseEntity<String>> assignToUserCouponAsync(@RequestAttribute("memberId") Long memberId) throws MemberNotFoundException, ExecutionException, InterruptedException { // user_id는 JwtAuthorizationFilter에서 넘겨줌.
         Optional<Member> member = memberService.findById(memberId);
         if(member.isPresent()) {
-            CompletableFuture<String> futureResult = couponservice.assignToUserAsync(member.get());
-            return ResponseEntity.ok().body(futureResult.get());
+            CompletableFuture<String> futureResult =
+                    couponservice.assignToUserAsync(member.get());
+            return completedFuture(ResponseEntity.ok().body(futureResult.get()));
         } else {
             throw new MemberNotFoundException(memberId);
         }
@@ -71,31 +71,29 @@ public class CouponController {
 
     @GetMapping("/user")
     public ResponseEntity<List<Coupon>> getUserCoupons(@RequestAttribute("memberId") Long memberId) throws MemberNotFoundException {
-        List<Coupon> coupons = couponservice.findByMember(memberId);
-        if(coupons == null || coupons.size() == 0) {
-            return ResponseEntity.noContent().build();
-        }
-        return ResponseEntity.ok(coupons);
+        return couponservice.findByMember(memberId)
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.noContent().build());
     }
 
+    // TODO : 제한 금액 체크. 파라미터로 주문 금액 체크 필요.
     @PutMapping("/{coupon_code}")
-    public ResponseEntity<?> updateWhetherUsingCoupon(@PathVariable("coupon_code") String couponCode,
+    public CompletableFuture<ResponseEntity<?>> updateWhetherUsingCoupon(@PathVariable("coupon_code") String couponCode,
                                        @RequestParam("is_used") Boolean isUsed,
                                        @RequestAttribute("memberId") Long memberId) throws CouponNotFoundException {
 
         log.info("updateIsEnabledCouponById controller current Thread name : " + Thread.currentThread().getName());
         CouponUtils.validateCouponCode(couponCode);
-        couponservice.updateIsEnabledCouponById(couponCode, memberId, isUsed);
-        return ResponseEntity.ok().build();
+        return CompletableFuture.runAsync(() ->
+                couponservice.updateIsEnabledCouponById(couponCode, memberId, isUsed)
+        ).thenApply((s) -> ResponseEntity.ok().build());
     }
 
     @GetMapping("/expired")
     public ResponseEntity<List<Coupon>> getExpiredCoupon() {
-        List<Coupon> coupons = couponservice.findExpiredToday();
-        if(coupons == null || coupons.size() == 0) {
-            return ResponseEntity.noContent().build();
-        }
-        return ResponseEntity.ok(coupons);
+        return couponservice.findExpiredToday()
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.noContent().build());
     }
 
 }

--- a/src/main/java/com/example/mycoupon/domain/Coupon.java
+++ b/src/main/java/com/example/mycoupon/domain/Coupon.java
@@ -57,7 +57,7 @@ public class Coupon implements Serializable {
 
     @JsonIgnore
     @ManyToOne(fetch = FetchType.LAZY) // default : 즉시 로딩
-    @JoinColumn(name = "member_id") 
+    @JoinColumn(name = "member_id")  // 외래키를 가진쪽이 연관관계 주인. (Coupon 테이블에서 member_id 외래키 관리)
     private Member member; // FK
 
 //    @OneToOne

--- a/src/main/java/com/example/mycoupon/exceptions/InternalFailureException.java
+++ b/src/main/java/com/example/mycoupon/exceptions/InternalFailureException.java
@@ -1,0 +1,8 @@
+package com.example.mycoupon.exceptions;
+
+public class InternalFailureException extends RuntimeException {
+
+    public InternalFailureException(Throwable cause) {
+        super("unknown server error : " + cause.getLocalizedMessage(), cause);
+    }
+}

--- a/src/main/java/com/example/mycoupon/repository/CouponRepository.java
+++ b/src/main/java/com/example/mycoupon/repository/CouponRepository.java
@@ -13,14 +13,14 @@ public interface CouponRepository extends JpaRepository<Coupon, Long> {
     Optional<Coupon> findByFreeUser();
 
     @Query(value = "SELECT * from coupon WHERE FORMATDATETIME(EXPIRED_AT, 'yyyy-MM-dd') = CURRENT_DATE()", nativeQuery = true)
-    List<Coupon> findByExpiredToday();
+    Optional<List<Coupon>> findByExpiredToday();
 
     Coupon findByCode(String code);
 
     List<Coupon> findByMemberId(Long memberId);
 
     @Query(value = "SELECT c from Coupon c WHERE c.member.id = :member_id")
-    List<Coupon> findByMemberNotUsed(@Param("member_id") Long memberId);
+    Optional<List<Coupon>> findByMemberNotUsed(@Param("member_id") Long memberId);
 
     // JPQL fetch join (Member entity LAZY Loading)
 //    @Query(value = "SELECT c from Coupon c join fetch m.member where c.isUsed = false")

--- a/src/main/java/com/example/mycoupon/service/CouponService.java
+++ b/src/main/java/com/example/mycoupon/service/CouponService.java
@@ -99,13 +99,13 @@ public class CouponService {
     }
 
     @Transactional(readOnly = true)
-    public List<Coupon> findExpiredToday() {
+    public Optional<List<Coupon>> findExpiredToday() {
         return couponRepository.findByExpiredToday();
     }
 
     @Cacheable(value="coupon-list", key="#memberId")
     @Transactional(readOnly = true)
-    public List<Coupon> findByMember(long memberId) {
+    public Optional<List<Coupon>> findByMember(long memberId) {
         log.info("@Cacheable findByMember method called.");
         return couponRepository.findByMemberNotUsed(memberId);
     }


### PR DESCRIPTION
이슈 #5 #6 #9 해결.
- CouponRepository의 각 메서드 리턴타입을 Optional<T>로 변경
- Controller에서는 Optional 처리에따라 map(),orElse() 메서드를 이용하여 다른 ResponseEntity 리턴 처리
- Controller에서 update, save 작업 리턴타입을 CompletableFuture<ResponseEntity<T>>로 변경
- async request 처리를 위해 filter, servlet 비동기 설정을 위해 `WebApplicationInitializer`을 구현한 클래스 추가.
- `WebApplicationInitializer` 구현 클래스의 `onStartUp` 메서드에서 비동기 설정